### PR TITLE
Setting correct vpc and sg for standalone ec2 instance

### DIFF
--- a/starter/terraform/modules/ec2/ec2.tf
+++ b/starter/terraform/modules/ec2/ec2.tf
@@ -1,33 +1,57 @@
 resource "aws_instance" "web" {
   ami           = var.aws_ami
   instance_type = "t3.micro"
-  key_name = "udacity"
+  key_name      = "udacity"
+  subnet_id     = data.aws_subnets.public.ids[0]
+
+  vpc_security_group_ids = [
+    aws_security_group.ec2_sg.id,
+    data.aws_security_group.default.id
+  ]
+
   tags = {
     Name = "ubuntu"
   }
 }
 
-resource "aws_security_group" "ec2_sg" {
-  name        = "ec2_sg"
-  vpc_id      = var.vpc_id
+data "aws_subnets" "public" {
+  filter {
+    name   = "vpc-id"
+    values = [var.vpc_id]
+  }
 
-  ingress {    
+  filter {
+    name   = "tag:Name"
+    values = ["*public*"]
+  }
+}
+
+data "aws_security_group" "default" {
+  name   = "default"
+  vpc_id = var.vpc_id
+}
+
+resource "aws_security_group" "ec2_sg" {
+  name   = "ec2_sg"
+  vpc_id = var.vpc_id
+
+  ingress {
     description = "web port"
-    from_port   = 80    
+    from_port   = 80
     to_port     = 80
-    protocol    = "tcp"    
+    protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
   ingress {
     description = "ssh port"
-    from_port   = 22    
+    from_port   = 22
     to_port     = 22
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]
   }
   ingress {
     description = "monitoring"
-    from_port   = 9100    
+    from_port   = 9100
     to_port     = 9100
     protocol    = "tcp"
     cidr_blocks = ["0.0.0.0/0"]


### PR DESCRIPTION
Currently, the ec2 instance is being created in the default VPC (instead of the one passed as an input variable for the module), and the security group wasn't being used at all.

I'm not sure if this is part of the project, but I don't think so 😅