### PR TITLE
Update aws_eks_cluster version to 1.28

### DIFF
--- a/starter/terraform/modules/eks/eks.tf
+++ b/starter/terraform/modules/eks/eks.tf
@@ -1,6 +1,6 @@
 resource "aws_eks_cluster" "cluster" {
    name     = "${var.name}-cluster"
-   version  = "1.21"
+   version  = "1.28"
    role_arn = aws_iam_role.eks_cluster_role.arn
 
    vpc_config {


### PR DESCRIPTION
Fix #6

```
│ Error: creating EKS Cluster (udacity-cluster): operation error EKS: CreateCluster, https response error StatusCode: 400, RequestID: 417bad2f-791a-448c-8d2d-94a04500335f, InvalidParameterException: unsupported Kubernetes version 1.21
│ 
│   with module.project_eks.aws_eks_cluster.cluster,
│   on modules/eks/eks.tf line 1, in resource "aws_eks_cluster" "cluster":
│    1: resource "aws_eks_cluster" "cluster" {
│ 
```

1.28 is the oldest version under standard support according to [EKS user guide](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html)